### PR TITLE
change CI to more of an integration test, improve docs + usability

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,13 @@
 version: 2.1
 
 workflows:
-  version: 2
-  build_all:
+  test:
     jobs:
       - build-run-linux
+
+# This CI build ensures that the demo both compiles and works correctly. For the runtime test,
+# we use an SDK key and flag key that are passed in via the CircleCI project configuration;
+# the flag is configured to return a true value.
 
 jobs:
   build-run-linux:
@@ -13,8 +16,18 @@ jobs:
     steps:
       - checkout
       - run:
+          name: insert SDK key and flag key into demo code
+          command: |
+            sed -i.bak "s/sdk_key *= *\".*\"/sdk_key = \"${LD_DEMO_SDK_KEY}\"/" main.go
+            sed -i.bak "s/feature_flag_key *= *\".*\"/feature_flag_key = \"${LD_DEMO_FLAG_KEY}\"/" main.go
+      - run:
           name: Install dependencies
           command: bundle install
       - run:
           name: Run hello
-          command: bundle exec ruby main.rb
+          command: bundle exec ruby main.rb | tee output.txt
+      - run:
+      - run:
+          name: Check output
+          command: |
+            grep "is true for this user" output.txt || (echo "Flag did not evaluate to expected true value" && exit 1)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,6 @@ jobs:
           name: Run hello
           command: bundle exec ruby main.rb | tee output.txt
       - run:
-      - run:
           name: Check output
           command: |
             grep "is true for this user" output.txt || (echo "Flag did not evaluate to expected true value" && exit 1)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,8 +18,8 @@ jobs:
       - run:
           name: insert SDK key and flag key into demo code
           command: |
-            sed -i.bak "s/sdk_key *= *\".*\"/sdk_key = \"${LD_DEMO_SDK_KEY}\"/" main.go
-            sed -i.bak "s/feature_flag_key *= *\".*\"/feature_flag_key = \"${LD_DEMO_FLAG_KEY}\"/" main.go
+            sed -i.bak "s/sdk_key *= *\".*\"/sdk_key = \"${LD_DEMO_SDK_KEY}\"/" main.rb
+            sed -i.bak "s/feature_flag_key *= *\".*\"/feature_flag_key = \"${LD_DEMO_FLAG_KEY}\"/" main.rb
       - run:
           name: Install dependencies
           command: bundle install

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 We've built a simple console application that demonstrates how LaunchDarkly's SDK works.
 
- Below, you'll find the basic build procedure, but for more comprehensive instructions, you can visit your [Quickstart page](https://app.launchdarkly.com/quickstart#/) or the [Go SDK reference guide](https://docs.launchdarkly.com/sdk/server-side/go).
+ Below, you'll find the basic build procedure, but for more comprehensive instructions, you can visit your [Quickstart page](https://app.launchdarkly.com/quickstart#/) or the [Ruby SDK reference guide](https://docs.launchdarkly.com/sdk/server-side/ruby).
 
 This demo requires Ruby version 2.5.0 or higher (or, for JRuby, 9.2.0 or higher).
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,23 @@
-### LaunchDarkly Sample Ruby Application  ###
-We've built a simple console application that demonstrates how LaunchDarkly's SDK works.  Below, you'll find the basic build procedure, but for more comprehensive instructions, you can visit your [Quickstart page](https://app.launchdarkly.com/quickstart#/).
-##### Build instructions  #####
-1. Install the LaunchDarkly Ruby SDK by running `bundle install`
-2. Copy your SDK key and feature flag key from your LaunchDarkly dashboard into `main.rb` 
-3. Run `bundle exec ruby main.rb`
+# LaunchDarkly Sample Ruby Application 
+
+We've built a simple console application that demonstrates how LaunchDarkly's SDK works.
+
+ Below, you'll find the basic build procedure, but for more comprehensive instructions, you can visit your [Quickstart page](https://app.launchdarkly.com/quickstart#/) or the [Go SDK reference guide](https://docs.launchdarkly.com/sdk/server-side/go).
+
+This demo requires Ruby version 2.5.0 or higher (or, for JRuby, 9.2.0 or higher).
+
+## Build instructions 
+
+1. Edit `main.rb` and set the value of `sdk_key` to your LaunchDarkly SDK key. If there is an existing boolean feature flag in your LaunchDarkly project that you want to evaluate, set `feature_flag_key` to the flag key.
+
+```ruby
+sdk_key = "1234567890abcdef"
+
+feature_flag_key = "my-flag"
+```
+
+2. If you have not installed the `bundler` tool, run `gem install bundler` on the command line.
+
+3. On the command line, run `bundle install`
+
+4. Run `bundle exec ruby main.rb`

--- a/main.rb
+++ b/main.rb
@@ -1,11 +1,27 @@
 require 'ldclient-rb'
 
-log = ::Logger.new($stdout)
-log.level = ::Logger::DEBUG
-config = LaunchDarkly::Config.new({:logger => log})
-# TODO : Enter your LaunchDarkly SDK key here
-client = LaunchDarkly::LDClient.new("YOUR_SDK_KEY", config)
+# Set sdk_key to your LaunchDarkly SDK key before running
+sdk_key = ""
 
+# Set feature_flag_key to the feature flag key you want to evaluate
+feature_flag_key = "my-boolean-flag"
+
+
+if sdk_key == ""
+  puts "Please edit main.rb to set sdk_key to your LaunchDarkly SDK key first"
+  exit 1
+end
+
+
+# The only custom configuration we are doing here is to reduce the amount of logging.
+log = ::Logger.new($stdout)
+log.level = ::Logger::WARN
+config = LaunchDarkly::Config.new({:logger => log})
+
+client = LaunchDarkly::LDClient.new(sdk_key, config)
+
+# Set up the user properties. This user should appear on your LaunchDarkly users dashboard
+# soon after you run the demo.
 user = {
   key: "bob@example.com",
   firstName: "Bob",
@@ -15,13 +31,13 @@ user = {
   }
 }
 
-# TODO : Enter the key for your feature flag here
-if client.variation("YOUR_FEATURE_FLAG_KEY", user, false)
-  # application code to show the feature
-  puts "Showing your feature to #{user[:key]}"
-else
-  # the code to run if the feature is off
-  puts "Not showing your feature to #{user[:key]}"
-end
+show_feature = client.variation(feature_flag_key, user, false)
 
-client.flush()
+puts "Feature flag '#{feature_flag_key}' is #{show_feature} for this user"
+
+# Calling client.close() ensures that the SDK shuts down cleanly before the program exits.
+# Unless you do this, the SDK may not have a chance to deliver analytics events to LaunchDarkly,
+# so the user properties and the flag usage statistics may not appear on your dashboard. In a
+# normal long-running application, events would be delivered automatically in the background
+# and you would not need to close the client.
+client.close()


### PR DESCRIPTION
This applies some changes that were previously made to https://github.com/launchdarkly/hello-go and hello-java:

* Make the code a bit simpler to update by moving the necessary variables up to the top of the file.
* Add clearer comments about what's going on in the code.
* Simplify output message to say that the result of the flag is true/false - rather than "showing the feature" vs. "not showing the feature", which doesn't necessarily correspond to how a flag is used in an application.
* Update the CI test to run the hello app _and verify that it gets the flag value_. I've put the necessary SDK key and flag key in the CircleCI environment variables for this project (it is the "Hello World demo / production" environment in the sandbox account).