### PR TITLE
fix: Add required dependencies and set a default flag

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,10 @@ source "https://rubygems.org"
 
 # gem "rails"
 gem 'launchdarkly-server-sdk', '~> 8.0.0'
+
+# Observer must be declared as of ruby 3.4
+gem 'observer', '~> 0.1.0'
+
+# Logger and benchmark must be declared as of ruby 3.5
+gem 'logger', '~> 1.7.0'
+gem 'benchmark', '~> 0.4.0'

--- a/main.rb
+++ b/main.rb
@@ -3,7 +3,7 @@ require 'ldclient-rb'
 sdk_key = ENV['LAUNCHDARKLY_SDK_KEY']
 
 # Set feature_flag_key to the feature flag key you want to evaluate
-feature_flag_key = ENV['LAUNCHDARKLY_FLAG_KEY']
+feature_flag_key = ENV['LAUNCHDARKLY_FLAG_KEY'] || 'sample-feature'
 
 ci = ENV['CI']
 


### PR DESCRIPTION
Ruby 3.4 fails with the following errors unless the observer gem dependancy is added. 

```
/opt/homebrew/lib/ruby/gems/3.4.0/gems/launchdarkly-server-sdk-8.0.0/lib/ldclient-rb/interfaces.rb:1: warning: observer was loaded from the standard library, but is not part of the default gems starting from Ruby 3.4.0.
You can add observer to your Gemfile or gemspec to silence this warning.
/opt/homebrew/Cellar/ruby/3.4.2/lib/ruby/3.4.0/bundled_gems.rb:82:in 'Kernel.require': cannot load such file -- observer (LoadError)
	from /opt/homebrew/Cellar/ruby/3.4.2/lib/ruby/3.4.0/bundled_gems.rb:82:in 'block (2 levels) in Kernel#replace_require'
	from /opt/homebrew/lib/ruby/gems/3.4.0/gems/launchdarkly-server-sdk-8.0.0/lib/ldclient-rb/interfaces.rb:1:in '<top (required)>'
	from /opt/homebrew/Cellar/ruby/3.4.2/lib/ruby/3.4.0/bundled_gems.rb:82:in 'Kernel.require'
	from /opt/homebrew/Cellar/ruby/3.4.2/lib/ruby/3.4.0/bundled_gems.rb:82:in 'block (2 levels) in Kernel#replace_require'
	from /opt/homebrew/lib/ruby/gems/3.4.0/gems/launchdarkly-server-sdk-8.0.0/lib/ldclient-rb.rb:9:in '<top (required)>'
	from /opt/homebrew/Cellar/ruby/3.4.2/lib/ruby/3.4.0/bundled_gems.rb:82:in 'Kernel.require'
	from /opt/homebrew/Cellar/ruby/3.4.2/lib/ruby/3.4.0/bundled_gems.rb:82:in 'block (2 levels) in Kernel#replace_require'
	from main.rb:1:in '<main>'
```

I additionally added two further dependencies logger and benchmark which had warnings they will be removed from standard library on ruby 3.5.

The flag also had no default if the user did not set a flag name so I have added sample-feature

I tested on ruby 3.4 and 3.2 to confirm this was backward compatible with older ruby versions