### PR TITLE
chore: update launchdarkly-server-sdk from ~> 8.0 to ~> 8.14

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 source "https://rubygems.org"
 
 # gem "rails"
-gem 'launchdarkly-server-sdk', '~> 8.0'
+gem 'launchdarkly-server-sdk', '~> 8.14'
 
 # Observer must be declared as of ruby 3.4
 gem 'observer', '~> 0.1.0'


### PR DESCRIPTION
## Summary

Updates the `launchdarkly-server-sdk` gem constraint in the Gemfile from `~> 8.0` to `~> 8.14`, ensuring the minimum version includes the latest release (8.14.0).

No deprecated APIs were found in the example code — all APIs used (`LDContext.create`, `variation`, `flag_tracker`) are current.

Tested successfully: SDK initializes and evaluates the `sample-feature` flag.

Link to Devin session: https://app.devin.ai/sessions/523c8324584f4ff5beae498731824942
Requested by: @kinyoklion